### PR TITLE
Deal with "from . import b".

### DIFF
--- a/snakefood3/gen_deps.py
+++ b/snakefood3/gen_deps.py
@@ -49,7 +49,12 @@ def get_all_imports_of_file(filename, python_path):
                 module = node.module
             else:
                 module = '.'.join(current_module.split('.')[:-node.level])
-                module += '.' + node.module
+                if node.module:
+                    module += '.' + node.module
+                else:
+                    # from . import b # module==None,name=='b'
+                    # maybe base_module.b or Base_module#b
+                    pass
             for name in node.names:
                 maybe_dir = path.join(
                     python_path,


### PR DESCRIPTION
Just skip `module += '.' + node.module` when `node.module` is `None`.

BTW, It would be better if this project could have a `.gitignore` to exclude `.pyc` files.